### PR TITLE
[ZR143] Regenerate CircleCI with guarded hook steps + resource_class via project.pp1.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       COLUMNS: '160'
       PATH: /root/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       CONTEXT_NAME: << pipeline.parameters.context_name >>
-      DEPS_INSTALL_TIMEOUT: '10m'
+      DEPS_INSTALL_TIMEOUT: 10m
       COVER_PACKAGES: geometry,geometry_manifolds_tests,geometry_tests
       TEST_PACKAGES: geometry_manifolds_tests geometry_tests
     docker:
@@ -42,7 +42,25 @@ jobs:
           echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
     - run:
         name: Build statistics
-        command: "set -x \nmkdir -p build-stats\n# image_name=`cat /.circleci-runner-config.json | jq -r .Job.docker[0].Image | envsubst`\n# registry_to_login=`echo ${image_name} | cut -d'/' -f1`\n# regctl registry login -u \"${DOCKER_USERNAME}\" -p \"${DOCKER_PASSWORD}\" \"${registry_to_login}\"\n\n# regctl manifest get --format raw-body \"${image_name}\" > build-stats/jobs/${CIRCLE_JOB}/image-manifest.json\n# regctl image digest \"${image_name}\" > build-stats/jobs/${CIRCLE_JOB}/image-digest.txt\n# echo ${image_name} > build-stats/jobs/${CIRCLE_JOB}/image-name.txt\n\nmkdir -p build-stats/envs\nmkdir -p build-stats/jobs/${CIRCLE_JOB}\nmkdir -p build-stats/jobs/${CIRCLE_JOB}/envs\necho -n \"${Z_REQS_SHA:-not-present}\"     > build-stats/jobs/${CIRCLE_JOB}/envs/Z_REQS_SHA\necho -n \"${IMAGE_VCS_SHA:-not-present}\"  > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_VCS_SHA\necho -n \"${IMAGE_NAME:-not-present}\"     > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_NAME\necho -n \"${CONTEXT_NAME:-not-present}\"   > build-stats/jobs/${CIRCLE_JOB}/envs/CONTEXT_NAME\necho -n \"${PYTHONOPTIMIZE:-not-present}\" > build-stats/jobs/${CIRCLE_JOB}/envs/PYTHONOPTIMIZE\n"
+        command: |
+          set -x
+          mkdir -p build-stats
+          # image_name=`cat /.circleci-runner-config.json | jq -r .Job.docker[0].Image | envsubst`
+          # registry_to_login=`echo ${image_name} | cut -d'/' -f1`
+          # regctl registry login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" "${registry_to_login}"
+
+          # regctl manifest get --format raw-body "${image_name}" > build-stats/jobs/${CIRCLE_JOB}/image-manifest.json
+          # regctl image digest "${image_name}" > build-stats/jobs/${CIRCLE_JOB}/image-digest.txt
+          # echo ${image_name} > build-stats/jobs/${CIRCLE_JOB}/image-name.txt
+
+          mkdir -p build-stats/envs
+          mkdir -p build-stats/jobs/${CIRCLE_JOB}
+          mkdir -p build-stats/jobs/${CIRCLE_JOB}/envs
+          echo -n "${Z_REQS_SHA:-not-present}"     > build-stats/jobs/${CIRCLE_JOB}/envs/Z_REQS_SHA
+          echo -n "${IMAGE_VCS_SHA:-not-present}"  > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_VCS_SHA
+          echo -n "${IMAGE_NAME:-not-present}"     > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_NAME
+          echo -n "${CONTEXT_NAME:-not-present}"   > build-stats/jobs/${CIRCLE_JOB}/envs/CONTEXT_NAME
+          echo -n "${PYTHONOPTIMIZE:-not-present}" > build-stats/jobs/${CIRCLE_JOB}/envs/PYTHONOPTIMIZE
     - store_artifacts:
         path: build-stats
         destination: build-stats
@@ -51,7 +69,7 @@ jobs:
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
-          printf '%s\n' 'PyContracts3>=7' 'numpy' 'scipy' 'zuper-commons-z7' > .requirements.txt
+          shyaml get-values install_requires < project.pp1.yaml > .requirements.txt
           saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/install-deps --heartbeat 30s --stats-interval 5s -- timeout ${DEPS_INSTALL_TIMEOUT} python3 -m pip install -r .requirements.txt
           rm .requirements.txt
     - run:
@@ -59,7 +77,7 @@ jobs:
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
-          : > .requirements_tests.txt
+          shyaml get-values tests_require < project.pp1.yaml > .requirements_tests.txt
           saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/install-testing-deps --heartbeat 30s --stats-interval 5s -- timeout ${DEPS_INSTALL_TIMEOUT} python3 -m pip install -r .requirements_tests.txt
           rm .requirements_tests.txt
     - run:
@@ -92,49 +110,78 @@ jobs:
         path: out/docs
         destination: docs
     - run:
+        background: true
+        name: services
+        command: |
+          TARGET=services
+          if make -n $TARGET ; then
+              make $TARGET
+          else
+              echo "Target $TARGET not defined"
+          fi
+    - run:
+        name: pre-circle-tests
+        command: |
+          TARGET=pre-circle-tests
+          if make -n $TARGET ; then
+              saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/pre-circle-tests --heartbeat 30s --stats-interval 5s -- make pre-circle-tests
+          else
+              echo "Target $TARGET not defined"
+          fi
+    - run:
         name: geometry_manifolds_tests
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
-          test_list=.circleci/geometry_manifolds_tests.tests
-          if [ ! -f "$test_list" ]; then
-            echo "$test_list is absent; no tests selected"
-            exit 0
-          fi
           set -euxo pipefail
           TEST_MODULES=$(split-tests <.circleci/geometry_manifolds_tests.tests)
           echo "TEST_MODULES=[$TEST_MODULES]"
           if [ -z "$TEST_MODULES" ]; then
-            echo "$TEST_MODULES is empty"
+            echo "\$TEST_MODULES is empty"
             exit 0
           else
-            echo "$TEST_MODULES is NOT empty"
+            echo "\$TEST_MODULES is NOT empty"
           fi
           mkdir -p out/test-results
-          xunit_output=$PWD/out/test-results/nose-${CIRCLE_NODE_INDEX}-geometry_manifolds_tests-xunit.xml
-          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/test-geometry_manifolds_tests --heartbeat 30s --stats-interval 5s -- timeout 30m nose2 --with-coverage --plugin nose2.plugins.junitxml --junit-xml --junit-xml-path ${xunit_output} $TEST_MODULES
+          xunit_output=$PWD/out/test-results/nose2-${CIRCLE_NODE_INDEX}-geometry_manifolds_tests-xunit.xml
+          timeout 30m nose2 --with-coverage \
+              --plugin nose2.plugins.junitxml \
+              --junit-xml \
+              --junit-xml-path ${xunit_output} \
+              $TEST_MODULES
+          # TODO: cover packages
     - run:
         name: geometry_tests
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
-          test_list=.circleci/geometry_tests.tests
-          if [ ! -f "$test_list" ]; then
-            echo "$test_list is absent; no tests selected"
-            exit 0
-          fi
           set -euxo pipefail
           TEST_MODULES=$(split-tests <.circleci/geometry_tests.tests)
           echo "TEST_MODULES=[$TEST_MODULES]"
           if [ -z "$TEST_MODULES" ]; then
-            echo "$TEST_MODULES is empty"
+            echo "\$TEST_MODULES is empty"
             exit 0
           else
-            echo "$TEST_MODULES is NOT empty"
+            echo "\$TEST_MODULES is NOT empty"
           fi
           mkdir -p out/test-results
-          xunit_output=$PWD/out/test-results/nose-${CIRCLE_NODE_INDEX}-geometry_tests-xunit.xml
-          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/test-geometry_tests --heartbeat 30s --stats-interval 5s -- timeout 30m nose2 --with-coverage --plugin nose2.plugins.junitxml --junit-xml --junit-xml-path ${xunit_output} $TEST_MODULES
+          xunit_output=$PWD/out/test-results/nose2-${CIRCLE_NODE_INDEX}-geometry_tests-xunit.xml
+          timeout 30m nose2 --with-coverage \
+              --plugin nose2.plugins.junitxml \
+              --junit-xml \
+              --junit-xml-path ${xunit_output} \
+              $TEST_MODULES
+          # TODO: cover packages
+    - run:
+        name: post-circle-tests
+        when: always
+        command: |
+          TARGET=post-circle-tests
+          if make -n $TARGET ; then
+              saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/post-circle-tests --heartbeat 30s --stats-interval 5s -- make post-circle-tests
+          else
+              echo "Target $TARGET not defined"
+          fi
     - store_test_results:
         path: out/test-results
     - run:
@@ -158,9 +205,9 @@ jobs:
           timeout 1m curl -O https://uploader.codecov.io/latest/linux/codecov || true
           chmod +x codecov || true
           timeout 1m ./codecov || true
-    resource_class: small.gen2
+    resource_class: small
 
-# sigil 1dde1d381561fe39b6d7758ee7a33016
+# sigil 322aefb63b025bd7c27301f1f5638b65
 # Agents: DO NOT MODIFY THIS FILE DIRECTLY - it is autogenerated using zuper-cli template from project.pp1.yaml
 # It is very likely you can obtain what you want by modifying the config.
 # In any case you need the user's explicit permissions.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,44 +1,31 @@
-repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
-  hooks:
-  - id: check-added-large-files
-  - id: check-case-conflict
-  - id: check-executables-have-shebangs
-  - id: check-merge-conflict
-  - id: check-symlinks
-- repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-  rev: '0.2.3'
-  hooks:
-  - id: yamlfmt
-    args:
-    - '--mapping'
-    - '2'
-    - '--sequence'
-    - '2'
-    - '--offset'
-    - '0'
-    - '--width'
-    - '150'
-    - '--preserve-quotes'
-- repo: https://github.com/aio-libs/sort-all
-  rev: v1.3.0
-  hooks:
-  - id: sort-all
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.10
-  hooks:
-  - id: ruff-format
-    name: ruff-format
-    args:
-    - '--line-length=130'
-  - id: ruff
-    name: ruff-lint
-    args:
-    - '--fix'
-    - '--select=I'
-    - '--line-length=130'
+exclude: .pre-commit-config.yaml|(.*autogen.*py)
 files: (^src/.*py)|(.*yaml)
-exclude: '.pre-commit-config.yaml|(.*autogen.*py)'
+repos:
+- hooks:
+  - {id: check-added-large-files}
+  - {id: check-case-conflict}
+  - {id: check-executables-have-shebangs}
+  - {id: check-merge-conflict}
+  - {id: check-symlinks}
+  repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+- hooks:
+  - args: [--mapping, '2', --sequence, '2', --offset, '0', --width, '150', --preserve-quotes]
+    id: yamlfmt
+  repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+  rev: 0.2.3
+- hooks:
+  - {id: sort-all}
+  repo: https://github.com/aio-libs/sort-all
+  rev: v1.3.0
+- hooks:
+  - args: [--line-length=130]
+    id: ruff-format
+    name: ruff-format
+  - args: [--fix, --select=I, --line-length=130]
+    id: ruff
+    name: ruff-lint
+  repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.10
 
-# sigil f6872e085fe9bd19b2afebd99dff214f
+# sigil 02fbf2b91c16b02e86d63a5ea12cd92b

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,7 +22,6 @@ prune src/*_tests*
 prune out
 prune assets
 
-
 #@ add local below
 
 include *.rst

--- a/project.pp1.yaml
+++ b/project.pp1.yaml
@@ -25,6 +25,7 @@ pypi:
 circleci:
   active: true
   test_python_versions: ['3.13']
+  resource_class: small
 
 python_syntax_version: '3.12'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,16 @@ name = "PyGeometry-z7"
 version = "7.2"
 readme = ""
 description = ""
-authors = [{ name = "Andrea Censi", email = "AndreaCensi@users.noreply.github.com" }]
-dependencies = ["PyContracts3>=7", "numpy", "scipy", "zuper-commons-z7"]
+authors = [{name = "Andrea Censi", email = "AndreaCensi@users.noreply.github.com"}]
+dependencies = [
+    "PyContracts3>=7",
+    "numpy",
+    "scipy",
+    "zuper-commons-z7",]
 
 [project.optional-dependencies]
-test = []
+test = [
+    ]
 
 [tool.poetry]
 name = "PyGeometry-z7"
@@ -15,13 +20,13 @@ version = "7.2"
 description = ""
 authors = ["Andrea Censi <AndreaCensi@users.noreply.github.com>"]
 packages = [
-    { from = "src", include = "geometry" },
-    { from = "src", include = "geometry/distances" },
-    { from = "src", include = "geometry/manifolds" },
-    { from = "src", include = "geometry/manifolds/todo" },
-    { from = "src", include = "geometry/subspaces" },
-    { from = "src", include = "geometry/utils" },
-]
+    {from = "src", include = "geometry"},
+    {from = "src", include = "geometry/distances"},
+    {from = "src", include = "geometry/manifolds"},
+    {from = "src", include = "geometry/manifolds/todo"},
+    {from = "src", include = "geometry/subspaces"},
+    {from = "src", include = "geometry/utils"},
+    ]
 
 [tool.poetry.dependencies]
 PyContracts3 = ">=7"
@@ -33,5 +38,6 @@ zuper-commons-z7 = "*"
 python = ">=3.12"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = [
+    "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Restores guarded services/pre-circle-tests/post-circle-tests AND sets resource_class=small in project.pp1.yaml (matching z7-prod) so the config regenerates cleanly without sigil drift. The prior config.yml was hand-edited, breaking regeneration.